### PR TITLE
Get rid of gratuitous mem::replace.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ type Thunk<'a> = Box<FnBox + Send + 'a>;
 
 impl Drop for Pool {
     fn drop(&mut self) {
-        mem::replace(&mut self.job_sender, None);
+        self.job_sender = None;
     }
 }
 


### PR DESCRIPTION
Nittiest of nit picks.
