### PR TITLE
Changed to Sync pool model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "scoped_threadpool"
 version = "0.1.6"
-authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
+authors = ["Marvin Löbel <loebel.marvin@gmail.com>", "Popog"]
 license = "MIT"
-build = "build.rs"
 
 description = "A library for scoped and cached threadpools."
 readme = "README.md"
@@ -12,11 +11,8 @@ documentation = "http://kimundi.github.io/scoped-threadpool-rs/scoped_threadpool
 repository = "https://github.com/Kimundi/scoped-threadpool-rs"
 keywords = ["thread", "scoped", "pool", "cached", "threadpool"]
 
-[build-dependencies]
-rustc_version = "0.1"
-
 [dev-dependencies]
-lazy_static = "*"
+lazy_static = "0.1.15"
 
 [features]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "http://kimundi.github.io/scoped-threadpool-rs/scoped_threadpool
 repository = "https://github.com/Kimundi/scoped-threadpool-rs"
 keywords = ["thread", "scoped", "pool", "cached", "threadpool"]
 
-[dev-dependencies]
-lazy_static = "0.1.15"
+[dependencies]
+crossbeam = "0.2.4"
 
 [features]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -32,22 +32,21 @@ use scoped_threadpool::Pool;
 
 fn main() {
     // Create a threadpool holding 4 threads
-    let mut pool = Pool::new(4);
+    let pool = Pool::new(4);
+    let manager = pool.manager();
 
     let mut vec = vec![0, 1, 2, 3, 4, 5, 6, 7];
 
     // Use the threads as scoped threads that can
     // reference anything outside this closure
-    pool.scoped(|scoped| {
+    manager.scoped(|scoped| {
         // Create references to each element in the vector ...
         for e in &mut vec {
-            // ... and add 1 to it in a seperate thread
+            // ... and add 1 to it in a separate thread
             // (execute() is safe to call in nightly)
-            unsafe {
-                scoped.execute(move || {
-                    *e += 1;
-                });
-            }
+            scoped.submit(move || {
+                *e += 1;
+            });
         }
     });
 

--- a/README.md
+++ b/README.md
@@ -33,18 +33,17 @@ use scoped_threadpool::Pool;
 fn main() {
     // Create a threadpool holding 4 threads
     let pool = Pool::new(4);
-    let manager = pool.manager();
 
     let mut vec = vec![0, 1, 2, 3, 4, 5, 6, 7];
 
     // Use the threads as scoped threads that can
     // reference anything outside this closure
-    manager.scoped(|scoped| {
+    pool.scoped(|scoped| {
         // Create references to each element in the vector ...
         for e in &mut vec {
             // ... and add 1 to it in a separate thread
             // (execute() is safe to call in nightly)
-            scoped.submit(move || {
+            scoped.execute(move || {
                 *e += 1;
             });
         }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -3,23 +3,12 @@
 
 extern crate test;
 #[macro_use]
-extern crate lazy_static;
 extern crate scoped_threadpool;
 
 use self::test::{Bencher, black_box};
-use scoped_threadpool::Pool;
-use std::sync::Mutex;
+use scoped_threadpool::{Pool, Anchored};
 
 // const MS_SLEEP_PER_OP: u32 = 1;
-
-lazy_static! {
-    static ref POOL_1: Mutex<Pool> = Mutex::new(Pool::new(1));
-    static ref POOL_2: Mutex<Pool> = Mutex::new(Pool::new(2));
-    static ref POOL_3: Mutex<Pool> = Mutex::new(Pool::new(3));
-    static ref POOL_4: Mutex<Pool> = Mutex::new(Pool::new(4));
-    static ref POOL_5: Mutex<Pool> = Mutex::new(Pool::new(5));
-    static ref POOL_8: Mutex<Pool> = Mutex::new(Pool::new(8));
-}
 
 fn fib(n: u64) -> u64 {
     let mut prev_prev: u64 = 1;
@@ -37,10 +26,9 @@ fn threads_interleaved_n(pool: &Pool)  {
     let size = 1024; // 1kiB
 
     let mut data = vec![1u8; size];
-    let manager = pool.manager();
-    manager.scoped(|s| {
+    pool.scoped(|s| {
         for e in data.iter_mut() {
-            s.submit(move || {
+            s.execute(move || {
                 *e += fib(black_box(1000 * (*e as u64))) as u8;
                 for i in 0..10000 { black_box(i); }
                 //thread::sleep_ms(MS_SLEEP_PER_OP);
@@ -51,22 +39,26 @@ fn threads_interleaved_n(pool: &Pool)  {
 
 #[bench]
 fn threads_interleaved_1(b: &mut Bencher) {
-    b.iter(|| threads_interleaved_n(&POOL_1.lock().unwrap()))
+    let pool = Pool::new(1);
+    b.iter(|| threads_interleaved_n(&pool))
 }
 
 #[bench]
 fn threads_interleaved_2(b: &mut Bencher) {
-    b.iter(|| threads_interleaved_n(&POOL_2.lock().unwrap()))
+    let pool = Pool::new(2);
+    b.iter(|| threads_interleaved_n(&pool))
 }
 
 #[bench]
 fn threads_interleaved_4(b: &mut Bencher) {
-    b.iter(|| threads_interleaved_n(&POOL_4.lock().unwrap()))
+    let pool = Pool::new(4);
+    b.iter(|| threads_interleaved_n(&pool))
 }
 
 #[bench]
 fn threads_interleaved_8(b: &mut Bencher) {
-   b.iter(|| threads_interleaved_n(&mut POOL_8.lock().unwrap()))
+    let pool = Pool::new(8);
+    b.iter(|| threads_interleaved_n(&pool))
 }
 
 fn threads_chunked_n(pool: &Pool) {
@@ -75,12 +67,11 @@ fn threads_chunked_n(pool: &Pool) {
    let bb_repeat = 50;
 
    let mut data = vec![0u32; size];
-   let manager = pool.manager();
-   let n = manager.threads();
-   manager.scoped(|s| {
+   let n = pool.threads();
+   pool.scoped(|s| {
        let l = (data.len() - 1) / n as usize + 1;
        for es in data.chunks_mut(l) {
-           s.submit(move || {
+           s.execute(move || {
                if es.len() > 1 {
                    es[0] = 1;
                    es[1] = 1;
@@ -99,30 +90,36 @@ fn threads_chunked_n(pool: &Pool) {
 
 #[bench]
 fn threads_chunked_1(b: &mut Bencher) {
-    b.iter(|| threads_chunked_n(&POOL_1.lock().unwrap()))
+    let pool = Pool::new(1);
+    b.iter(|| threads_chunked_n(&pool))
 }
 
 #[bench]
 fn threads_chunked_2(b: &mut Bencher) {
-    b.iter(|| threads_chunked_n(&POOL_2.lock().unwrap()))
+    let pool = Pool::new(2);
+    b.iter(|| threads_chunked_n(&pool))
 }
 
 #[bench]
 fn threads_chunked_3(b: &mut Bencher) {
-    b.iter(|| threads_chunked_n(&POOL_3.lock().unwrap()))
+    let pool = Pool::new(3);
+    b.iter(|| threads_chunked_n(&pool))
 }
 
 #[bench]
 fn threads_chunked_4(b: &mut Bencher) {
-    b.iter(|| threads_chunked_n(&POOL_4.lock().unwrap()))
+    let pool = Pool::new(4);
+    b.iter(|| threads_chunked_n(&pool))
 }
 
 #[bench]
 fn threads_chunked_5(b: &mut Bencher) {
-    b.iter(|| threads_chunked_n(&POOL_5.lock().unwrap()))
+    let pool = Pool::new(5);
+    b.iter(|| threads_chunked_n(&pool))
 }
 
 #[bench]
 fn threads_chunked_8(b: &mut Bencher) {
-    b.iter(|| threads_chunked_n(&POOL_8.lock().unwrap()))
+    let pool = Pool::new(8);
+    b.iter(|| threads_chunked_n(&pool))
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,0 +1,128 @@
+#![feature(test)]
+#![feature(const_fn)]
+
+extern crate test;
+#[macro_use]
+extern crate lazy_static;
+extern crate scoped_threadpool;
+
+use self::test::{Bencher, black_box};
+use scoped_threadpool::Pool;
+use std::sync::Mutex;
+
+// const MS_SLEEP_PER_OP: u32 = 1;
+
+lazy_static! {
+    static ref POOL_1: Mutex<Pool> = Mutex::new(Pool::new(1));
+    static ref POOL_2: Mutex<Pool> = Mutex::new(Pool::new(2));
+    static ref POOL_3: Mutex<Pool> = Mutex::new(Pool::new(3));
+    static ref POOL_4: Mutex<Pool> = Mutex::new(Pool::new(4));
+    static ref POOL_5: Mutex<Pool> = Mutex::new(Pool::new(5));
+    static ref POOL_8: Mutex<Pool> = Mutex::new(Pool::new(8));
+}
+
+fn fib(n: u64) -> u64 {
+    let mut prev_prev: u64 = 1;
+    let mut prev = 1;
+    let mut current = 1;
+    for _ in 2..(n+1) {
+        current = prev_prev.wrapping_add(prev);
+        prev_prev = prev;
+        prev = current;
+    }
+    current
+}
+
+fn threads_interleaved_n(pool: &Pool)  {
+    let size = 1024; // 1kiB
+
+    let mut data = vec![1u8; size];
+    let manager = pool.manager();
+    manager.scoped(|s| {
+        for e in data.iter_mut() {
+            s.submit(move || {
+                *e += fib(black_box(1000 * (*e as u64))) as u8;
+                for i in 0..10000 { black_box(i); }
+                //thread::sleep_ms(MS_SLEEP_PER_OP);
+            });
+        }
+    });
+}
+
+#[bench]
+fn threads_interleaved_1(b: &mut Bencher) {
+    b.iter(|| threads_interleaved_n(&POOL_1.lock().unwrap()))
+}
+
+#[bench]
+fn threads_interleaved_2(b: &mut Bencher) {
+    b.iter(|| threads_interleaved_n(&POOL_2.lock().unwrap()))
+}
+
+#[bench]
+fn threads_interleaved_4(b: &mut Bencher) {
+    b.iter(|| threads_interleaved_n(&POOL_4.lock().unwrap()))
+}
+
+#[bench]
+fn threads_interleaved_8(b: &mut Bencher) {
+   b.iter(|| threads_interleaved_n(&mut POOL_8.lock().unwrap()))
+}
+
+fn threads_chunked_n(pool: &Pool) {
+   // Set this to 1GB and 40 to get good but slooow results
+   let size = 1024 * 1024 * 10 / 4; // 10MiB
+   let bb_repeat = 50;
+
+   let mut data = vec![0u32; size];
+   let manager = pool.manager();
+   let n = manager.threads();
+   manager.scoped(|s| {
+       let l = (data.len() - 1) / n as usize + 1;
+       for es in data.chunks_mut(l) {
+           s.submit(move || {
+               if es.len() > 1 {
+                   es[0] = 1;
+                   es[1] = 1;
+                   for i in 2..es.len() {
+                       // Fibonnaci gets big fast,
+                       // so just wrap around all the time
+                       es[i] = black_box(es[i-1].wrapping_add(es[i-2]));
+                       for i in 0..bb_repeat { black_box(i); }
+                   }
+               }
+               //thread::sleep_ms(MS_SLEEP_PER_OP);
+           });
+       }
+   });
+}
+
+#[bench]
+fn threads_chunked_1(b: &mut Bencher) {
+    b.iter(|| threads_chunked_n(&POOL_1.lock().unwrap()))
+}
+
+#[bench]
+fn threads_chunked_2(b: &mut Bencher) {
+    b.iter(|| threads_chunked_n(&POOL_2.lock().unwrap()))
+}
+
+#[bench]
+fn threads_chunked_3(b: &mut Bencher) {
+    b.iter(|| threads_chunked_n(&POOL_3.lock().unwrap()))
+}
+
+#[bench]
+fn threads_chunked_4(b: &mut Bencher) {
+    b.iter(|| threads_chunked_n(&POOL_4.lock().unwrap()))
+}
+
+#[bench]
+fn threads_chunked_5(b: &mut Bencher) {
+    b.iter(|| threads_chunked_n(&POOL_5.lock().unwrap()))
+}
+
+#[bench]
+fn threads_chunked_8(b: &mut Bencher) {
+    b.iter(|| threads_chunked_n(&POOL_8.lock().unwrap()))
+}

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-extern crate rustc_version;
-
-fn main() {
-    if rustc_version::version_matches(">= 1.4.0") {
-        println!("cargo:rustc-cfg=compiler_has_scoped_bugfix");
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,17 +20,16 @@
 //! fn main() {
 //!     // Create a threadpool holding 4 threads
 //!     let pool = Pool::new(4);
-//!     let manager = pool.manager();
 //!
 //!     let mut vec = vec![0, 1, 2, 3, 4, 5, 6, 7];
 //!
 //!     // Use the threads as scoped threads that can
 //!     // reference anything outside this closure
-//!     manager.scoped(|scope| {
+//!     pool.scoped(|scope| {
 //!         // Create references to each element in the vector ...
 //!         for e in &mut vec {
 //!             // ... and add 1 to it in a separate thread
-//!             scope.submit(move || {
+//!             scope.execute(move || {
 //!                 *e += 1;
 //!             });
 //!         }
@@ -42,12 +41,59 @@
 
 #![warn(missing_docs)]
 
-use std::thread::{self, JoinHandle};
+extern crate crossbeam;
+
+use std::borrow::{Borrow, BorrowMut};
+use std::marker::PhantomData;
 use std::mem;
-use std::borrow::Borrow;
-use std::sync::mpsc::{channel, Sender, Receiver};
-use std::sync::atomic::{AtomicIsize,Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Condvar};
+use std::thread::{self};
+use std::usize;
+
+use crossbeam::sync::MsQueue;
+
+struct Semaphore {
+    lock: Mutex<(usize, bool)>,
+    cvar: Condvar,
+}
+
+impl Semaphore {
+    fn new(count: usize) -> Semaphore {
+        Semaphore {
+            lock: Mutex::new((count, false)),
+            cvar: Condvar::new(),
+        }
+    }
+
+    fn panicked(&self) -> bool {
+        self.lock.lock().unwrap().1
+    }
+
+    fn acquire(&self, count: usize) -> bool {
+        let mut v = self.lock.lock().unwrap();
+        while v.0 < count {
+            v = self.cvar.wait(v).unwrap();
+        }
+        v.0 -= count;
+        v.1 |= thread::panicking();
+        v.1
+    }
+
+    fn acquire_all(&self) -> (usize, bool) {
+        let mut v = self.lock.lock().unwrap();
+        v.1 |= thread::panicking();
+        (mem::replace(&mut v.0, 0), v.1)
+    }
+
+    fn release(&self) {
+        let mut v = self.lock.lock().unwrap();
+        v.0 += 1;
+        v.1 |= thread::panicking();
+        self.cvar.notify_one();
+    }
+}
 
 //    d88b  .d88b.  d8888b.
 //    `8P' .8P  Y8. 88  `8D
@@ -56,35 +102,35 @@ use std::sync::{Arc, Mutex, RwLock};
 // db. 88  `8b  d8' 88   8D
 // Y8888P   `Y88P'  Y8888P'
 
-type JobResult = Result<(), JoinHandle<()>>;
-
-struct JobGuard {
-    value: JobResult,
-    result_tx: Sender<JobResult>,
-}
-
-impl Drop for JobGuard {
-    fn drop(&mut self) {
-        self.result_tx.send( mem::replace(&mut self.value, Ok(())) ).unwrap();
-    }
-}
-
 /// TODO: Convert to std::boxed::FnBox. Blocked by rust-lang/rust#28796
-trait FnBox {
-    fn call_box(self: Box<Self>);
+trait FnBox<A, R> {
+    fn call_box(self: Box<Self>, a: A) -> R;
 }
 
-impl<F: FnOnce()> FnBox for F {
-    fn call_box(self: Box<F>) {
+impl<F: FnOnce()> FnBox<(), ()> for F {
+    fn call_box(self: Box<F>, _: ()) {
         (*self)()
     }
 }
 
-type Thunk<'a> = Box<FnBox + Send + 'a>;
+struct SemaphoreGuard<'pool>(&'pool Semaphore);
 
-struct Message {
-    job: Thunk<'static>,
-    result_tx: Sender<JobResult>,
+impl <'pool> Drop for SemaphoreGuard<'pool> {
+    fn drop(&mut self) {
+        self.0.release()
+    }
+}
+
+type Thunk<'a> = Box<FnBox<(), ()> + Send + 'a>;
+
+enum Message {
+    Job(Thunk<'static>),
+    ScopedJob {
+        job: Thunk<'static>,
+        semaphore: &'static Semaphore,
+    },
+    Remove,
+    Dropping,
 }
 
 // .d8888. d88888b d8b   db d888888b d888888b d8b   db d88888b db
@@ -94,64 +140,48 @@ struct Message {
 // db   8D 88.     88  V888    88      .88.   88  V888 88.     88booo.
 // `8888Y' Y88888P VP   V8P    YP    Y888888P VP   V8P Y88888P Y88888P
 
-struct Sentinel<'a> {
-    job_rx: Arc<Mutex<Receiver<Option<Message>>>>,
-    done: &'a Arc<RwLock<()>>,
+struct Sentinel {
+    pool: Arc<PoolShared>,
     respawn: bool,
 }
 
-impl <'a> Sentinel<'a> {
-    fn new(job_rx: Arc<Mutex<Receiver<Option<Message>>>>, done: Arc<RwLock<()>>) {
-        // Create a channel the send the JoinHandle to the thread
-        let (tx, rx) = channel();
-
-        // Create the thread
-        let thread = thread::spawn(move || {
-            // Get the JoinHandle
-            let mut thread = rx.recv().unwrap();
-            mem::drop(rx);
-
+impl Sentinel {
+    fn new(pool: Arc<PoolShared>) {
+        thread::spawn(move || {
             // Will spawn a new thread on panic unless it is cancelled.
             let sentinel = Sentinel {
-                job_rx: job_rx,
-                done: &done,
+                pool: pool,
                 respawn: true,
             };
 
-            let _guard = done.read().unwrap();
-
             loop {
-                let message = {
-                    // Only lock jobs for the time it takes
-                    // to get a job, not run it.
-                    let lock = sentinel.job_rx.lock().unwrap();
-                    lock.recv()
-                };
-
-                thread = match message {
-                    /// Execute the job and send the response
-                    Ok(Some(Message{job, result_tx})) => {
-                        let mut job_guard = JobGuard {
-                            result_tx: result_tx,
-                            value: Err(thread),
-                        };
-
-                        job.call_box();
-
-                        mem::replace(&mut job_guard.value, Ok(())).unwrap_err()
-                    }
-                    // A message to kill a single thread or the pool was dropped.
-                    Ok(None) | Err(_) => {
+                match sentinel.pool.jobs.pop() {
+                    // Execute the job and send the response
+                    Message::Job(job) => {
+                        job.call_box(());
+                    },
+                    // Execute the job and send the response
+                    Message::ScopedJob{job, semaphore} => {
+                        // If the scope is panicked, don't execute jobs from it
+                        if !semaphore.panicked() {
+                            let _guard = SemaphoreGuard(semaphore);
+                            job.call_box(());
+                        }
+                    },
+                    // A message to kill a single thread
+                    Message::Remove => {
                         sentinel.die();
                         return
-                    }
+                    },
+                    // A message the pool is being dropped.
+                    Message::Dropping => {
+                        sentinel.pool.threads.release();
+                        sentinel.die();
+                        return
+                    },
                 }
             }
-
         });
-
-        // Send the JoinHandle to the thread
-        tx.send(thread).unwrap();
     }
 
     // Destroy this sentinel and let the thread die.
@@ -160,10 +190,10 @@ impl <'a> Sentinel<'a> {
     }
 }
 
-impl <'a> Drop for Sentinel<'a> {
+impl Drop for Sentinel {
     fn drop(&mut self) {
         if self.respawn {
-            Sentinel::new(self.job_rx.clone(), self.done.clone())
+            Sentinel::new(self.pool.clone())
         }
     }
 }
@@ -175,177 +205,211 @@ impl <'a> Drop for Sentinel<'a> {
 // 88      `8b  d8' `8b  d8' 88booo.
 // 88       `Y88P'   `Y88P'  Y88888P
 
-struct ThreadDone(Arc<RwLock<()>>);
-
-impl Drop for ThreadDone {
-    fn drop(&mut self) {
-        let _guard = self.0.write().unwrap();
-    }
+struct PoolShared {
+    threads: Semaphore,
+    jobs: MsQueue<Message>,
 }
 
 /// A threadpool that acts as a handle to a number of threads spawned at construction.
+// `Drop` will not block.
 pub struct Pool {
-    job_tx: Mutex<Sender<Option<Message>>>,
-    job_rx: Arc<Mutex<Receiver<Option<Message>>>>,
-    count: AtomicIsize,
-    thread_done: ThreadDone,
-}
-
-fn adjust_helper(n: isize, job_rx: &Arc<Mutex<Receiver<Option<Message>>>>, thread_done: &Arc<RwLock<()>>, job_tx: &Sender<Option<Message>>) {
-    // spawn n threads, put them in waiting mode
-    for _ in 0..n {
-        Sentinel::new(job_rx.clone(), thread_done.clone())
-    }
-    // Send kill mesages to threads
-    for _ in n..0 {
-        job_tx.send(None).unwrap();
-    }
+    shared: Arc<PoolShared>,
+    count: AtomicUsize,
 }
 
 impl Pool {
     /// Construct a threadpool with the given number of threads.
-    pub fn new(n: isize) -> Pool {
+    pub fn new(n: usize) -> Self {
+        let shared = Arc::new(PoolShared{
+            threads: Semaphore::new(0),
+            jobs: MsQueue::new(),
+        });
 
-        let thread_done = Arc::new(RwLock::new(()));
-        let (job_tx, job_rx) = channel();
-        let job_rx = Arc::new(Mutex::new(job_rx));
-        adjust_helper(n, &job_rx, &thread_done, &job_tx);
+        // Spawn n threads, put them in waiting mode
+        for _ in 0..n {
+            Sentinel::new(shared.clone())
+        }
 
-        let p = Pool{
-            job_tx: Mutex::new(job_tx),
-            job_rx: job_rx,
-            count: AtomicIsize::new(n),
-            thread_done: ThreadDone(thread_done),
-        };
-        p
-    }
-
-    /// Create a manager for the pool. Pools can have multiple managers at the same time.
-    ///
-    /// Creating a manager from a pool requires acquiring a lock, so cloning an existing manager
-    /// for a pool is usually cheaper.
-    pub fn manager<'pool>(&'pool self) -> Manager<&'pool Pool> {
-        Manager{
-            jobs: 0,
-            job_tx: self.job_tx.lock().unwrap().clone(),
-            results: channel(),
-            pool: self,
+        Pool{
+            shared: shared,
+            count: AtomicUsize::new(n),
         }
     }
 
-    /// Gets the number of threads
-    pub fn threads(&self) -> isize {
-        self.count.load(Ordering::Relaxed)
-    }
-}
+    /// Adds threads to the pool, returning the previous number of threads. The number of threads
+    /// will not overflow.
+    pub fn add_threads(&self, val: usize) -> usize {
+        let mut current = self.count.load(Ordering::Relaxed);
+        if val == 0 { return current; }
 
-
-// .88b  d88.  .d8b.  d8b   db  .d8b.   d888b  d88888b d8888b.
-// 88'YbdP`88 d8' `8b 888o  88 d8' `8b 88' Y8b 88'     88  `8D
-// 88  88  88 88ooo88 88V8o 88 88ooo88 88      88ooooo 88oobY'
-// 88  88  88 88~~~88 88 V8o88 88~~~88 88  ooo 88~~~~~ 88`8b
-// 88  88  88 88   88 88  V888 88   88 88. ~8~ 88.     88 `88.
-// YP  YP  YP YP   YP VP   V8P YP   YP  Y888P  Y88888P 88   YD
-
-/// A manager for controlling a threadpool.
-pub struct Manager<P: Borrow<Pool>> {
-    jobs: usize,
-    job_tx: Sender<Option<Message>>,
-    results: (Sender<JobResult>, Receiver<JobResult>),
-    pool: P,
-}
-
-impl <P: Borrow<Pool>> Manager<P> {
-    /// Create a new Manager
-    pub fn new(pool: P) -> Self {
-        let job_tx = pool.borrow().job_tx.lock().unwrap().clone();
-        Manager{
-            jobs: 0,
-            job_tx: job_tx,
-            results: channel(),
-            pool: pool,
+        loop {
+            let old = self.count.compare_and_swap(current, current.saturating_add(val), Ordering::Relaxed);
+            if current == old { break }
+            current = old;
         }
+
+        // Spawn n threads, put them in waiting mode
+        for _ in 0..(current.saturating_add(val) - current) {
+            Sentinel::new(self.shared.clone())
+        }
+
+        current
     }
 
-    /// Gets the pool
-    pub fn pool(&self) -> &Pool { self.pool.borrow() }
+    /// Removes threads from the pool, returning the previous number of threads. The number of
+    /// threads will not underflow.
+    pub fn sub_threads(&self, val: usize) -> usize {
+        let mut current = self.count.load(Ordering::Relaxed);
+        if val == 0 { return current; }
 
-    /// Submits a static job for execution on the threadpool.
-    ///
-    /// The body of the closure will be send to one of the
-    /// internal threads, and this method itself will not wait
-    /// for its completion.
-    pub fn submit<F: FnOnce() + Send + 'static>(&mut self, f: F) {
-        let f = Box::new(f);
-        let f = Message{ job: f, result_tx: self.results.0.clone() };
+        loop {
+            let old = self.count.compare_and_swap(current, current.saturating_sub(val), Ordering::Relaxed);
+            if current == old { break }
+            current = old;
+        }
 
-        self.job_tx.send(Some(f)).unwrap();
-    }
+        // Send kill messages to threads
+        for _ in 0..(current - current.saturating_sub(val)) {
+            self.shared.jobs.push(Message::Remove);
+        }
 
-    /// Borrows the manger and allows executing jobs on other
-    /// threads during that scope via the argument of the closure.
-    ///
-    /// This method will block until the closure and all its jobs have
-    /// run to completion.
-    pub fn scoped<'manager, R, F: FnOnce(&mut Scope<'manager>) -> R>(&'manager self, f: F) -> R {
-        let mut scope = Scope {
-            job_tx: &self.job_tx,
-            results: channel(),
-            jobs: 0,
-        };
-        f(&mut scope)
-    }
-
-    /// Adjusts the number of threads in the pool as requested. If n is positive, threads will be
-    /// added to the pool. If n is negative, threads will be removed from the pool. This call is
-    /// non-blocking.
-    pub fn adjust_threads(&self, n: isize) {
-        self.pool.borrow().count.fetch_add(n, Ordering::Relaxed);
-        adjust_helper(n, &self.pool.borrow().job_rx, &self.pool.borrow().thread_done.0, &self.job_tx)
+        current
     }
 
     /// Sets the number of threads in the pool to the value requested, adding and removing threads
-    /// as needed. This call is non-blocking.
-    pub fn set_threads(&self, n: isize) {
-        let old = self.pool.borrow().count.swap(n, Ordering::Relaxed);
-        adjust_helper(n - old, &self.pool.borrow().job_rx, &self.pool.borrow().thread_done.0, &self.job_tx)
-    }
+    /// as needed. Returns the old number of threads
+    pub fn set_threads(&self, new: usize) -> usize {
+        let old = self.count.swap(new, Ordering::Relaxed);
 
-    /// Gets the number of threads
-    pub fn threads(&self) -> isize {
-        self.pool.borrow().count.load(Ordering::Relaxed)
-    }
-
-    /// Blocks until all submitted jobs have run to completion.
-    /// If the child thread panics, `Err` is returned with the parameter given to `panic`.
-    pub fn join_all(&mut self) -> thread::Result<()> {
-        while self.jobs > 0 {
-            self.jobs -= 1;
-            if let Err(thread) = self.results.1.recv().unwrap() {
-                return thread.join()
+        if new > old {
+            // Spawn n threads, put them in waiting mode
+            for _ in 0..(new-old) {
+                Sentinel::new(self.shared.clone())
+            }
+        } else {
+            // Send kill messages to threads
+            for _ in 0..(old-new) {
+                self.shared.jobs.push(Message::Remove);
             }
         }
-        Ok(())
-    }
-}
 
-impl <P: Clone+Borrow<Pool>> Clone for Manager<P> {
-    fn clone(&self) -> Self {
-        Manager{
-            jobs: 0,
-            job_tx: self.job_tx.clone(),
-            results: channel(),
-            pool: self.pool.clone(),
+        old
+    }
+
+    /// Sets the number of threads if the current value is the same as the `current` value.
+    ///
+    /// The return value is always the previous value. If it is equal to current, then the number
+    /// of threads was updated.
+    pub fn compare_and_swap(&self, current: usize, new: usize) -> usize {
+        let old = self.count.compare_and_swap(current, new, Ordering::Relaxed);
+
+        // If current is equal, perform changes
+        if current == old {
+            if new > old {
+                // Spawn n threads, put them in waiting mode
+                for _ in 0..(new-old) {
+                    Sentinel::new(self.shared.clone())
+                }
+            } else {
+                // Send kill messages to threads
+                for _ in 0..(old-new) {
+                    self.shared.jobs.push(Message::Remove);
+                }
+            }
         }
+
+        old
+    }
+
+    /// Gets the number of threads. The number of threads may change immediately after this call
+    /// is made.
+    pub fn threads(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    /// Submits a static job for execution on the threadpool.
+    ///
+    /// The body of the closure will be send to one of the internal threads, and this method itself
+    /// will not wait for its completion.
+    pub fn execute<F: 'static+Send+FnOnce()>(&self, f: F) {
+        self.shared.jobs.push(Message::Job(Box::new(f)));
+    }
+
+    /// Borrows the pool and allows executing jobs on other threads during that scope via the
+    /// argument of the closure.
+    ///
+    /// This method will block until the closure and all its jobs have run to completion.
+    pub fn scoped<'pool, R, F: FnOnce(&mut Scope<'pool>) -> R>(&'pool self, f: F) -> R {
+        let mut scope = Scope::new(&self.shared.jobs);
+        f(&mut scope)
     }
 }
 
-impl <P: Borrow<Pool>> Drop for Manager<P> {
+impl Drop for Pool {
     fn drop(&mut self) {
+        // Kill all the threads, but don't bother blocking
+        self.set_threads(0);
+    }
+}
+
+//  .d8b.  d8b   db  .o88b. db   db  .d88b.  d8888b. d88888b d8888b.
+// d8' `8b 888o  88 d8P  Y8 88   88 .8P  Y8. 88  `8D 88'     88  `8D
+// 88ooo88 88V8o 88 8P      88ooo88 88    88 88oobY' 88ooooo 88   88
+// 88~~~88 88 V8o88 8b      88~~~88 88    88 88`8b   88~~~~~ 88   88
+// 88   88 88  V888 Y8b  d8 88   88 `8b  d8' 88 `88. 88.     88  .8D
+// YP   YP VP   V8P  `Y88P' YP   YP  `Y88P'  88   YD Y88888P Y8888D'
+
+/// An anchored thread pool that will block on `Drop` until all threads are cleaned up.
+pub struct Anchored {
+    pool: Pool,
+    _marker: PhantomData<* const ()>, // TODO: Convert to !Send. Blocked by rust-lang/rust#13231
+}
+
+// TODO: Convert to !Send. Blocked by rust-lang/rust#13231
+unsafe impl Sync for Anchored {}
+
+impl Anchored {
+    /// Construct a threadpool with the given number of threads.
+    pub fn new(n: usize) -> Self { Anchored{ pool: Pool::new(n), _marker: PhantomData } }
+}
+
+impl Deref for Anchored {
+    type Target = Pool;
+    fn deref(&self) -> &Self::Target { &self.pool }
+}
+
+impl DerefMut for Anchored {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.pool }
+}
+
+impl AsRef<Pool> for Anchored {
+    fn as_ref(&self) -> &Pool { &self.pool }
+}
+
+impl AsMut<Pool> for Anchored {
+    fn as_mut(&mut self) -> &mut Pool { &mut self.pool }
+}
+
+impl Borrow<Pool> for Anchored {
+    fn borrow(&self) -> &Pool { &self.pool }
+}
+
+impl BorrowMut<Pool> for Anchored {
+    fn borrow_mut(&mut self) -> &mut Pool { &mut self.pool }
+}
+
+impl Drop for Anchored {
+    fn drop(&mut self) {
+        // See how many threads we have
+        let n = self.pool.count.swap(0, Ordering::Relaxed);
+
+        // Send drop messages to threads
+        for _ in 0..n {
+            self.pool.shared.jobs.push(Message::Dropping);
+        }
+
         if !thread::panicking() {
-            if let Err(e) = self.join_all() {
-                panic!(e)
-            }
+            self.pool.shared.threads.acquire(n);
         }
     }
 }
@@ -357,48 +421,76 @@ impl <P: Borrow<Pool>> Drop for Manager<P> {
 // db   8D Y8b  d8 `8b  d8' 88      88.
 // `8888Y'  `Y88P'  `Y88P'  88      Y88888P
 
-/// Handle to the scope during which the manager is borrowed.
-pub struct Scope<'manager> {
-    job_tx: &'manager Sender<Option<Message>>,
-    results: (Sender<JobResult>, Receiver<JobResult>),
-    jobs: usize,
+/// Handle to the scope.
+pub struct Scope<'pool> {
+    jobs: &'pool MsQueue<Message>,
+    job_count: usize,
+    semaphore: Semaphore,
 }
 
-impl <'manager> Scope<'manager> {
+impl <'pool> Scope<'pool> {
+    fn new(jobs: &'pool MsQueue<Message>) -> Self {
+        Scope{
+            jobs: jobs,
+            job_count: 0,
+            semaphore: Semaphore::new(0),
+        }
+    }
+
     /// Submit a job for execution on the threadpool.
     ///
-    /// The body of the closure will be send to one of the
-    /// internal threads, and this method itself will not wait
-    /// for its completion.
-    pub fn submit<'scope, F: FnOnce() + Send + 'scope>(&'scope mut self, f: F) {
-        let f = Box::new(f);
-        let f = unsafe { mem::transmute::<Thunk<'scope>, Thunk<'static>>(f) };
-        let f = Message{ job: f, result_tx: self.results.0.clone() };
+    /// The body of the closure will be send to one of the internal threads, and this method
+    /// itself will not wait for its completion.
+    pub fn execute<'scope, F: 'scope+Send+FnOnce()>(&'scope mut self, f: F)  {
+        // Check the current state and count any completed jobs
+        let (finished, panicked) = self.semaphore.acquire_all();
+        self.job_count -= finished;
 
-        self.job_tx.send(Some(f)).unwrap();
-        self.jobs += 1;
+        // Block job submission if a panic occurs. Also panic if needed.
+        if panicked {
+            if thread::panicking() {
+                return;
+            } else {
+                panic!("Scoped thread panicked");
+            }
+        }
+
+        // Block job overflow
+        if self.job_count == usize::MAX {
+            panic!("Job overflow, max jobs is {}", usize::MAX)
+        }
+        self.job_count += 1;
+
+        let f = Box::new(f);
+        self.jobs.push(Message::ScopedJob{
+            job: unsafe {
+                mem::transmute::<Thunk<'scope>, Thunk<'static>>(f)
+            },
+            semaphore: unsafe {
+                mem::transmute::<&'scope Semaphore, &'static Semaphore>(&self.semaphore)
+            },
+        });
     }
 
     /// Blocks until all submitted jobs have run to completion.
-    /// If the child thread panics, `Err` is returned with the parameter given to `panic`.
-    pub fn join_all(&mut self) -> thread::Result<()> {
-        while self.jobs > 0 {
-            self.jobs -= 1;
-            if let Err(thread) = self.results.1.recv().unwrap() {
-                return thread.join()
+    pub fn wait_all(&mut self) {
+        // Wait for job completion.
+        let panicked = self.semaphore.acquire(mem::replace(&mut self.job_count, 0));
+
+        // Panic if needed
+        if panicked {
+            if thread::panicking() {
+                return;
+            } else {
+                panic!("Scoped thread panicked");
             }
         }
-        Ok(())
     }
 }
 
-impl <'manager> Drop for Scope<'manager> {
+impl <'pool> Drop for Scope<'pool> {
     fn drop(&mut self) {
-        if !thread::panicking() {
-            if let Err(e) = self.join_all() {
-                panic!(e)
-            }
-        }
+        self.wait_all();
     }
 }
 
@@ -411,21 +503,23 @@ impl <'manager> Drop for Scope<'manager> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Pool, Manager};
+    use super::{Pool, Anchored};
+    use std::borrow::Borrow;
     use std::thread;
     use std::time::Duration;
     use std::sync::mpsc::{channel, sync_channel};
 
-    #[test]
-    fn smoketest() {
-        let pool = Pool::new(4);
-        let manager = pool.manager();
+    #[test] fn smoketest_pool() { smoketest(Pool::new(4)) }
+    #[test] fn smoketest_anchored() { smoketest(Anchored::new(4)) }
+
+    fn smoketest<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
 
         for i in 1..7 {
             let mut vec = vec![0, 1, 2, 3, 4];
-            manager.scoped(|s| {
+            pool.scoped(|s| {
                 for e in vec.iter_mut() {
-                    s.submit(move || {
+                    s.execute(move || {
                         *e += i;
                     });
                 }
@@ -440,66 +534,53 @@ mod tests {
         }
     }
 
+    #[test] fn add_pool() { add(Pool::new(0)) }
+    #[test] fn add_anchored() { add(Anchored::new(0)) }
 
-    #[test]
-    fn managed() {
-        let pool = Pool::new(4);
-        let manager = Manager::new(pool);
-
-        for i in 1..7 {
-            let mut vec = vec![0, 1, 2, 3, 4];
-            manager.scoped(|s| {
-                for e in vec.iter_mut() {
-                    s.submit(move || {
-                        *e += i;
-                    });
-                }
-            });
-
-            let mut vec2 = vec![0, 1, 2, 3, 4];
-            for e in vec2.iter_mut() {
-                *e += i;
-            }
-
-            assert_eq!(vec, vec2);
-        }
-    }
-
-
-    #[test]
-    fn add() {
-        let pool = Pool::new(0);
-        let manager = pool.manager();
-        manager.adjust_threads(1);
-        manager.scoped(|scoped| {
-            let manager = manager.clone();
-            scoped.submit(move || {
-                manager.adjust_threads(1);
+    fn add<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.add_threads(1);
+        pool.scoped(|scoped| {
+            let pool = &pool;
+            scoped.execute(move || {
+                pool.sub_threads(1);
             });
         });
     }
 
-    #[test]
-    fn remove() {
-        let pool = Pool::new(2);
-        let manager = pool.manager();
-        manager.adjust_threads(-1);
-        manager.scoped(|scoped| {
-            scoped.submit(move || {
+    #[test] fn remove_pool() { remove(Pool::new(2)) }
+    #[test] fn remove_anchored() { remove(Anchored::new(2)) }
+
+    fn remove<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.sub_threads(1);
+        pool.scoped(|scoped| {
+            scoped.execute(move || {
             });
         });
     }
 
-    #[test]
-    fn double_borrow() {
-        let pool = Pool::new(2);
-        let manager = pool.manager();
-        manager.scoped(|s| {
-            let manager = pool.manager();
-            s.submit(move || {
-                manager.scoped(|s2| {
+    #[test] fn remove_underflow_pool() { remove_underflow(Pool::new(0)) }
+    #[test] fn remove_underflow_anchored() { remove_underflow(Anchored::new(0)) }
+
+    fn remove_underflow<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.sub_threads(1);
+        assert_eq!(pool.threads(), 0);
+    }
+
+
+    #[test] fn double_borrow_pool() { double_borrow(Pool::new(2)) }
+    #[test] fn double_borrow_anchored() { double_borrow(Anchored::new(2)) }
+
+    fn double_borrow<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.scoped(|s| {
+            let pool = &pool;
+            s.execute(move || {
+                pool.scoped(|s2| {
                     let (tx, rx) = sync_channel(0);
-                    s2.submit(move || {
+                    s2.execute(move || {
                         tx.send(1).unwrap();
                     });
                     rx.recv().unwrap();
@@ -508,13 +589,29 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test] fn thread_panic_pool() { thread_panic(Pool::new(2)) }
+    #[test] fn thread_panic_anchored() { thread_panic(Anchored::new(2)) }
+
+    fn thread_panic<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        let (tx, rx) = channel();
+        pool.execute(move || {
+            let _tx = tx;
+            if false { let _ = _tx.send(()); }
+            panic!();
+        });
+        rx.recv().unwrap_err();
+    }
+
     #[should_panic]
-    fn thread_panic() {
-        let pool = Pool::new(4);
-        let manager = pool.manager();
-        manager.scoped(|scoped| {
-            scoped.submit(move || {
+    #[test] fn scoped_thread_panic_pool() { scoped_thread_panic(Pool::new(4)) }
+    #[should_panic]
+    #[test] fn scoped_thread_panic_anchored() { scoped_thread_panic(Anchored::new(4)) }
+
+    fn scoped_thread_panic<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.scoped(|scoped| {
+            scoped.execute(move || {
                 panic!()
             });
         });
@@ -522,44 +619,54 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn scope_panic() {
-        let pool = Pool::new(4);
-        let manager = pool.manager();
-        manager.scoped(|_scoped| {
+    fn scoped_panic_pool() { scope_panic(Pool::new(4)) }
+    #[test]
+    #[should_panic]
+    fn scoped_panic_anchored() { scope_panic(Anchored::new(4)) }
+
+    fn scope_panic<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.scoped(|_scoped| {
             panic!()
         });
     }
 
     #[test]
     #[should_panic]
-    fn pool_panic() {
-        let _pool = Pool::new(4);
+    fn panic_pool() { pool_panic(Pool::new(4)) }
+    #[test]
+    #[should_panic]
+    fn panic_anchored() { pool_panic(Anchored::new(4)) }
+
+    fn pool_panic<P: Borrow<Pool>>(pool: P) {
+        let _pool = pool.borrow();
         panic!()
     }
 
-    #[test]
-    fn join_all() {
-        let pool = Pool::new(4);
-        let manager = pool.manager();
+    #[test] fn wait_all_pool() { wait_all(Pool::new(4)) }
+    #[test] fn wait_all_anchored() { wait_all(Anchored::new(4)) }
+
+    fn wait_all<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
 
         let (tx_, rx) = channel();
 
-        manager.scoped(|scoped| {
+        pool.scoped(|scoped| {
             let tx = tx_.clone();
-            scoped.submit(move || {
+            scoped.execute(move || {
                 thread::sleep(Duration::from_millis(1000));
                 tx.send(2).unwrap();
             });
 
             let tx = tx_.clone();
-            scoped.submit(move || {
+            scoped.execute(move || {
                 tx.send(1).unwrap();
             });
 
-            scoped.join_all().unwrap();
+            scoped.wait_all();
 
             let tx = tx_.clone();
-            scoped.submit(move || {
+            scoped.execute(move || {
                 tx.send(3).unwrap();
             });
         });
@@ -567,12 +674,13 @@ mod tests {
         assert_eq!(rx.iter().take(3).collect::<Vec<_>>(), vec![1, 2, 3]);
     }
 
-    #[test]
-    fn simple() {
-        let pool = Pool::new(4);
-        let manager = pool.manager();
-        manager.scoped(|scoped| {
-            scoped.submit(move || {
+    #[test] fn simple_pool() { simple(Pool::new(4)) }
+    #[test] fn simple_anchored() { simple(Anchored::new(4)) }
+
+    fn simple<P: Borrow<Pool>>(pool: P) {
+        let pool = pool.borrow();
+        pool.scoped(|scoped| {
+            scoped.execute(move || {
             });
         });
     }


### PR DESCRIPTION
Changed threadpools to be Sync, which required the addition of a non-sync manager type in between Pool and Scoped.

Added Sentinels to respawn threads (make respawn optional in the future?).

Moved benchmarks to benches directory.

Removed build script and rustc dependency, changed lazy_static dependency to a fixed version number.

Some renaming of methods.
